### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) service for interacting with Heptabase backup data. This service allows AI assistants like Claude to search, retrieve, analyze, and export Heptabase whiteboards and cards.
 
+<a href="https://glama.ai/mcp/servers/@LarryStanley/heptabse-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@LarryStanley/heptabse-mcp/badge" alt="Heptabase MCP server" />
+</a>
+
 ## Features
 
 - 🔍 Search whiteboards and cards


### PR DESCRIPTION
This PR adds a badge for the [Heptabase MCP](https://glama.ai/mcp/servers/@LarryStanley/heptabse-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@LarryStanley/heptabse-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@LarryStanley/heptabse-mcp/badge" alt="Heptabase MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.